### PR TITLE
#18: Automate dev env setup with direnv.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,69 @@
+# Automate support and setup of dev environment using Poetry or uv, preferring Poetry.
+# Code borrowed from direnv wiki (https://github.com/direnv/direnv/wiki/Python)
+# Some modifications borrowed from Anadon
+
+# Modified from the Direnv wiki entry for uv
+layout_uv() {
+  PYPROJECT_TOML="${PYPROJECT_TOML:-pyproject.toml}"
+  if [[ ! -f "$PYPROJECT_TOML" ]]; then
+    log_status "No pyproject.toml found. Run \`uv init\` manually to create a \`$PYPROJECT_TOML\` first."
+    return 1
+  fi
+
+  if [[ -d ".venv" ]]; then
+    VIRTUAL_ENV="$(pwd)/.venv"
+  fi
+
+  if [[ -z $VIRTUAL_ENV || ! -d $VIRTUAL_ENV ]]; then
+    log_status "No virtual environment exists. Executing \`uv venv\` to create one."
+    uv venv
+    VIRTUAL_ENV="$(pwd)/.venv"
+  fi
+
+  PATH_add "$VIRTUAL_ENV/bin"
+  export UV_ACTIVE=1  # or VENV_ACTIVE=1
+  export VIRTUAL_ENV
+
+  # Check lockfile
+  if uv lock --check 2>&1 >/dev/null; then
+    uv lock
+  fi
+
+  uv sync
+}
+
+main() {
+  if ! has uv; then
+    log_status "APIS uses uv for project management and is required for development."
+    yn=
+
+    while [[ ! $yn ]]; do
+      read -p "Would you like to install uv? [yes/no] " yn
+      case $yn in
+          [Yy]* )
+            # uv standalone installer
+            if has curl; then curl -LsSf https://astral.sh/uv/install.sh | sh
+            else wget -qO- https://astral.sh/uv/install.sh | sh; fi
+            ;;
+          [Nn]* )
+            log_error "uv not installed, aborting."
+            return 1
+            ;;
+          * )
+            yn=
+            echo "Please answer y(es) or n(o)."
+            ;;
+      esac
+    done
+  fi
+
+  log_status "Setting up development environment..."
+  if ! layout_uv; then
+    log_error "Something went wrong while setting up the dev environment. Check console output and logs."
+  fi
+}
+
+main
+
+# Load secrets from a designated .envrc secrets file
+if [[ -f .envrc.secrets ]]; then source_env .envrc.secrets; fi

--- a/.envrc.secrets.example
+++ b/.envrc.secrets.example
@@ -1,3 +1,2 @@
-source venv/bin/activate
 export GITHUB_USER=
 export GITHUB_CR_PAT=

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ test-db.sqlite3-journal
 registration/resources/nametag/apis/tmp*.html
 .idea/
 .coverage
-.envrc
+.envrc.secrets
 fm_eventmanager/maintenance_mode_state.txt
 localhost.crt
 localhost.key


### PR DESCRIPTION
Committed .envrc will check for and ask to install uv if it's not installed, then set up the venv and check the lockfile before resolving dependencies. Also will add .venv/bin to the PATH while you're in there so there's no need to activate the venv explicitly.

Automation baybeee

Originally done with poetry in 11f3bd1, adapting to use uv instead since that's what furthemore's using upstream.

Closes #18 