### PR TITLE
Fix registration form: address dropdown binding and birthdate day field

### DIFF
--- a/registration/templates/templatetags/basic_attendee_form.html
+++ b/registration/templates/templatetags/basic_attendee_form.html
@@ -81,11 +81,10 @@
     </div>
     <div class="col-sm-5">
         <select autocomplete="address-level3" class="form-control bfh-states"
+                data-country="country"
                 {% if event.venue %}
-                data-country="{{attendee.country|default:event.venue.country }}"
                 data-state="{{attendee.state|default:event.venue.state }}"
                 {% else %}
-                data-country="{{ attendee.country }}"
                 data-state="{{ attendee.state }}"
                 {% endif %}
 
@@ -103,11 +102,7 @@
     </div>
     <div class="col-sm-6">
         <select autocomplete="country" class="form-control bfh-countries"
-                {% if event.venue %}
-                data-country="{{ attendee.country|default:event.venue.country }}"
-                {% else %}
-                data-country="{{ attendee.country }}"
-                {% endif %}
+                data-country="{% if attendee.country %}{{ attendee.country }}{% elif event.venue and event.venue.country %}{{ event.venue.country }}{% else %}US{% endif %}"
                 id="country" name="country" required></select>
     </div>
     <div class="col-sm-offset-3 help-block with-errors" style="padding-left:15px;"></div>
@@ -148,7 +143,9 @@
         </div>
 
         <div class="col-sm-3">
-          <input type="number" name="bday" id="bday" class="form-control" placeholder="Day" value="{{attendee.birthdate|date:"d"}}" max="31" min="1" maxlength="2" required autocomplete="bday-day" />
+          <select name="bday" id="bday" class="form-control" required autocomplete="bday-day" disabled>
+            <option value="">Day</option>
+          </select>
         </div>
 
         <input type="hidden" name="birthDate" id="birthDate" value="{{attendee.birthdate|date:"Y-m-d"}}{{ attendee.dob }}">


### PR DESCRIPTION
- Fix state/region dropdown to properly bind to country selection
- Simplify country field default value logic
- Change birthdate day from number input to select dropdown to prevent invalid dates

Fixes #13