### PR TITLE
Accept signatures consisting of only one line

### DIFF
--- a/registration/templates/registration/registration-form.html
+++ b/registration/templates/registration/registration-form.html
@@ -438,7 +438,7 @@
 
           let signature = $("#jsign_signature");
           let nativeData = signature.jSignature("getData", "native");
-          if (nativeData.length < 2) {
+          if (nativeData.length < 1) {
             alert("You must sign to acknowledge your acceptance of the Code of Conduct.");
               $("#register").one('click', register_click);
               return;


### PR DESCRIPTION
Currently, we expect at least 2 lines for a signature and give the user an opaque "you must sign to accept the code of conduct" error if their signature consists of only one line. This change allows single line signatures.