### PR TITLE
46 discounts cause incorrect cart calculation

### DIFF
--- a/fm_eventmanager/settings.py
+++ b/fm_eventmanager/settings.py
@@ -255,14 +255,14 @@ INSTALLED_APPS = [
     "allauth.mfa",
     "registration",
     "nested_inline",
-    # "django_prometheus",
+    "django_prometheus",
     "django_vite",
     "csp",
     "axes",  # P1.10: brute-force protection on auth endpoints
 ]
 
 MIDDLEWARE = [
-    # "django_prometheus.middleware.PrometheusBeforeMiddleware",
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "django.middleware.security.SecurityMiddleware",
     # WhiteNoise serves /static/ from gunicorn. Position is documented:
     # right after SecurityMiddleware so security headers apply to static
@@ -374,16 +374,13 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 # https://docs.djangoproject.com/en/5.2/topics/cache/
 
 CACHES = {
-    # "default": {
-    #     "BACKEND": "django_redis.cache.RedisCache",
-    #     "LOCATION": os.getenv("DJANGO_REDIS_URL", "redis://redis:6379/1"),
-    #     "OPTIONS": {
-    #         "CLIENT_CLASS": "django_redis.client.DefaultClient",
-    #     },
-    #     "KEY_PREFIX": os.getenv("DJANGO_REDIS_KEY_PREFIX", "apis"),
-    # }
     "default": {
-        "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": os.getenv("DJANGO_REDIS_URL", "redis://redis:6379/1"),
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        },
+        "KEY_PREFIX": os.getenv("DJANGO_REDIS_KEY_PREFIX", "apis"),
     }
 }
 

--- a/registration/paypal_payments.py
+++ b/registration/paypal_payments.py
@@ -155,9 +155,9 @@ def create_unpaid_paypal_order(
                 breakdown=AmountBreakdown(
                     item_total=Money(
                         currency_code="USD",
-                        value=str(registration_amount),
+                        value=str(registration_total),
                     ),
-                    discount=Money(currency_code="USD", value=str(discount)),
+                    discount=Money(currency_code="USD", value=str(discount_decimal)),
                 ),
             ),
             "items": registrations,

--- a/registration/static/js/payments-paypal.js
+++ b/registration/static/js/payments-paypal.js
@@ -58,9 +58,7 @@ if (window.paypal) {
                             country: $("#country").val(),
                             postal: $("#postal").val(),
                             source_id: data.orderID,
-                        },
-                        charityDonation: $("#donateCharity").val(),
-                        orgDonation: $("#donateOrg").val()
+                        }
                     })
                 );
 

--- a/registration/templates/registration/checkout.html
+++ b/registration/templates/registration/checkout.html
@@ -31,7 +31,9 @@
             <td>{{ item.priceLevel }}</td>
             <td>${{ item.priceLevel.basePrice }} <a class="deleteAttendee" id="delete_{{ item.id }}">&times; Remove</a></td>
           {% else %}
-            <td>{{ item.badge.attendee }} - {{ item.priceLevel }}</td>
+            <td>{{ item.badge.attendee }}</td>
+            <td>{{ item.priceLevel }}</td>
+            <td>${{ item.priceLevel.basePrice }}</td>
           {% endif %}
           </tr>
           {% for option in item.options %}

--- a/registration/templates/registration/checkout.html
+++ b/registration/templates/registration/checkout.html
@@ -26,7 +26,7 @@
         </tr>
         {% for item in orderItems %}
           <tr class="active">
-            {% if item.attendee %}
+          {% if item.attendee %}
             <td>{% attendee_get_first item.attendee %} {{ item.attendee.lastName }}</td>
             <td>{{ item.priceLevel }}</td>
             <td>${{ item.priceLevel.basePrice }} <a class="deleteAttendee" id="delete_{{ item.id }}">&times; Remove</a></td>
@@ -131,44 +131,6 @@
         {% endif %}
         <div class="container" style="width: inherit">
           <form class="form-horizontal" role="form" data-toggle="validator">
-
-            <h3>Extra Donations</h3>
-            <div class="col-sm-11 col-sm-offset-1" style="padding-left:0px;padding-bottom:10px;">
-              {% if event.charity %}
-                If you would like to make an extra gift to our annual charity,
-                {% if event.charity.url %}<a href="{{ event.charity.url }}">{{ event.charity }}</a>{% else %}
-                  {{ event.charity }}{% endif %}, or to the convention, please enter it below.
-              {% else %}
-                If you would like to make an extra gift to the convention, please enter it below.
-              {% endif %}
-            </div>
-            {% if event.charity %}
-              <div class="form-group">
-                <label for="donateCharity" class="col-sm-3 control-label">Donate to {{ event.charity }}</label>
-                <div class="col-sm-4">
-                  <div class="input-group">
-                    <div class="input-group-addon">$</div>
-                    <input type="number" min="0" step="1" pattern="^\d+(?:\.\d{0,2})?$" placeholder="0.00"
-                           id="donateCharity" class="form-control validate"
-                           data-error="Please use only numbers and a decimal."/>
-                  </div>
-                </div>
-                <div class="col-sm-offset-3 help-block with-errors" style=" padding-left:15px;"></div>
-              </div>
-            {% endif %}
-
-            <div class="form-group">
-              <label for="donateOrg" class="col-sm-3 control-label">Donate to {{ event }}</label>
-              <div class="col-sm-4">
-                <div class="input-group">
-                  <div class="input-group-addon">$</div>
-                  <input type="number" min="0" step="1" pattern="^\d+(?:\.\d{0,2})?$" placeholder="0.00" id="donateOrg"
-                         class="form-control validate" data-error="Please use only numbers and a decimal."/>
-                </div>
-              </div>
-              <div class="col-sm-offset-3 help-block with-errors" style=" padding-left:15px;"></div>
-            </div>
-            <hr/>
 
             {% if event.collectBillingAddress %}
               <h3>Billing Information</h3>

--- a/registration/tests/test_ordering.py
+++ b/registration/tests/test_ordering.py
@@ -1,0 +1,97 @@
+from datetime import timedelta
+
+from django.utils import timezone
+
+from registration.models import (
+    Badge,
+    Discount,
+    OrderItem,
+)
+from registration.tests.common import OrdersTestCase
+from registration.views.ordering import get_discount_total, get_line_item_total
+
+tz = timezone.get_current_timezone()
+now = timezone.now()
+ten_days = timedelta(days=10)
+one_day = timedelta(days=1)
+
+
+class TestOrderingModule(OrdersTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.badge = Badge(event=self.event, registeredDate=now, badgeName="New Staff")
+        self.badge.save()
+
+        self.staff_reg_item = OrderItem(
+            badge=self.badge, priceLevel=self.price_45, enteredBy="WEB", enteredDate=now
+        )
+        self.staff_reg_item.save()
+
+        self.discount_percent_50 = Discount(
+            codeName="HalfOff", percentOff=50, startDate=now, endDate=now + ten_days
+        )
+        self.discount_expired = Discount(
+            codeName="NoGood", percentOff=100, startDate=now - ten_days, endDate=now - one_day
+        )
+
+        self.discount_percent_50.save()
+        self.discount_expired.save()
+
+    def test_get_discount_total_nonexistent(self):
+        self.assertEqual(
+            get_discount_total("ShitIMadeUp", 100), 0, "nonexistent discounts should total to 0"
+        )
+
+    def test_get_discount_total_expired(self):
+        self.assertEqual(
+            get_discount_total(self.discount_expired.codeName, 100),
+            0,
+            "expired discounts should total to 0",
+        )
+
+    def test_get_discount_total_from_code(self):
+        self.assertEqual(
+            get_discount_total(self.discount.codeName, 100),
+            5,
+            "fixed amount coupons should return their amountOff",
+        )
+        self.assertEqual(
+            get_discount_total(self.discount_percent_50.codeName, 100),
+            50,
+            "percentage amount coupons should calculate properly",
+        )
+
+    def test_get_discount_total_from_model(self):
+        self.assertEqual(
+            get_discount_total(self.discount, 100),
+            5,
+            "fixed amount coupons should return their amountOff",
+        )
+        self.assertEqual(
+            get_discount_total(self.discount_percent_50, 100),
+            50,
+            "percentage amount coupons should calculate properly",
+        )
+
+    def test_get_line_item_total_cart_item_no_discount(self):
+        self.assertTupleEqual(get_line_item_total(self.staff_reg_item), (45.00, 0.00))
+
+    def test_get_line_item_total_cart_item_fixed_discount(self):
+        self.assertTupleEqual(
+            get_line_item_total(self.staff_reg_item, self.discount.codeName), (45.00, 5.00)
+        )
+
+    def test_get_line_item_total_cart_item_percent_discount(self):
+        self.assertTupleEqual(
+            get_line_item_total(self.staff_reg_item, self.discount_percent_50.codeName),
+            (45.00, 22.50),
+        )
+
+    def test_get_line_item_total_cart_item_expired_discount(self):
+        self.assertTupleEqual(
+            get_line_item_total(self.staff_reg_item, self.discount_expired.codeName), (45.00, 0)
+        )
+
+    def test_get_line_item_total_cart_item(self):
+        pass

--- a/registration/tests/test_paypal_payments.py
+++ b/registration/tests/test_paypal_payments.py
@@ -206,7 +206,7 @@ class TestCreateUnpaidPaypalOrder(OrdersTestCase):
         call_args = mock_create.call_args[0][0]
         breakdown = call_args["body"].purchase_units[0].amount.breakdown
         self.assertEqual("5", breakdown.discount.value)
-        self.assertEqual("40", breakdown.item_total.value)
+        self.assertEqual("45", breakdown.item_total.value)
 
     @patch("paypalserversdk.controllers.orders_controller.OrdersController.create_order")
     def test_A1_4_donation_items_split_into_own_purchase_unit(self, mock_create):
@@ -364,7 +364,7 @@ class TestCreateUnpaidPaypalOrderDonationSplit(OrdersTestCase):
 
         # Registration unit bears the discount: 50.00 - 5 = 45.00.
         self.assertEqual("45.00", reg_pu.amount.value)
-        self.assertEqual("45.00", reg_pu.amount.breakdown.item_total.value)
+        self.assertEqual("50.00", reg_pu.amount.breakdown.item_total.value)
         self.assertEqual("5", reg_pu.amount.breakdown.discount.value)
         self.assertEqual("REF-MIXED", reg_pu.invoice_id)
         self.assertEqual("REF-MIXED", reg_pu.custom_id)

--- a/registration/views/ordering.py
+++ b/registration/views/ordering.py
@@ -354,20 +354,20 @@ def get_discount_total(disc: str | Discount, subtotal: Decimal) -> Decimal:
     try:
         discount = Discount.objects.get(codeName=disc)
     except (Discount.DoesNotExist, ValueError, TypeError):
-        return 0
+        return Decimal(0)
     if discount.isValid():
         if discount.amountOff:
             return discount.amountOff
         elif discount.percentOff:
             return Decimal(subtotal * (discount.percentOff) / 100)
-    return 0
+    return Decimal(0)
 
 
 def get_line_item_total(
     item: Cart | OrderItem, disc: str | None = ""
 ) -> tuple[Decimal | int, Decimal | int]:
-    item_total: Decimal | int = 0
-    discount: Decimal | int = 0
+    item_total = Decimal(0)
+    discount = Decimal(0)
     if isinstance(item, Cart):
         post_data = json.loads(item.formData)
         pdp = post_data["priceLevel"]

--- a/registration/views/ordering.py
+++ b/registration/views/ordering.py
@@ -341,7 +341,7 @@ def get_order_item_option_total(options):
     return optionTotal
 
 
-def get_discount_total(disc, subtotal):
+def get_discount_total(disc: str | Discount, subtotal: Decimal) -> Decimal:
     """Accept either a ``Discount`` model instance or a string code name.
 
     Callers in ``cart.py``/``onsite.py``/``onsite_admin.py`` hand in already-
@@ -359,7 +359,7 @@ def get_discount_total(disc, subtotal):
         if discount.amountOff:
             return discount.amountOff
         elif discount.percentOff:
-            return Decimal(float(subtotal) * float(discount.percentOff) / 100)
+            return Decimal(subtotal * (discount.percentOff) / 100)
     return 0
 
 
@@ -525,7 +525,7 @@ def create_paypal_order(request: HttpRequest) -> JsonResponse:
         badge = cast(Badge, order_item.badge)
         translated_cart.append(
             {
-                "name": str(event) + " " + str(order_item.priceLevel) + " - " + str(badge.attendee),
+                "name": f"{event} {order_item.priceLevel} - {badge.attendee}",
                 "total": cast(Decimal, item_total),
                 "donation": False,
             }
@@ -555,7 +555,7 @@ def create_paypal_order(request: HttpRequest) -> JsonResponse:
             }
         )
 
-    total = subtotal + porg + pcharity
+    total = subtotal + total_discount + porg + pcharity
 
     # We only want to set up to capture payment if there is payment due
     if total > 0:


### PR DESCRIPTION
Discounts were causing PayPal checkout to fail with an error. We were calculating order totals incorrectly in the function that created the order data and sent it to PayPal.